### PR TITLE
Change to getLocalUrl() which takes into account that multiple differ…

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -438,14 +438,30 @@ var Intercooler = Intercooler || (function() {
     if (paramsToPush) {
       baseURL = baseURL + "?";
       var vars = {};
-      data.replace(/([^=&]+)=([^&]*)/gi, function(m,key,value) {
-        vars[key] = value;
+      var keyArray = [];      
+      paramsToPush.split(",").forEach(element => {
+        keyArray[element.trim()] = [];        
       });
+      data.replace(/([^=&]+)=([^&]*)/gi, function(m,key,value) {
+        if (keyArray[key]){
+          keyArray[key].push(value);          
+          vars[key] = keyArray[key];
+        }     
+      });
+      var counter = 0;
       $(paramsToPush.split(",")).each(function(index) {
         var param = $.trim(this);
-        var value = vars[param] || "";
-        baseURL += (index == 0) ? "" : "&";
-        baseURL += param + "=" + value;
+        var value = vars[param] || "";                
+        for (const child of value) {    
+          baseURL += (counter == 0) ? "" : "&";      
+          baseURL += param + "=" + child;  
+          counter++;
+        }
+        if (typeof value === 'string') {
+          baseURL += (counter == 0) ? "" : "&";
+          baseURL += param + "=" + value;
+          counter++;
+        }
       });
     }
     return baseURL;

--- a/test/unit_tests.html
+++ b/test/unit_tests.html
@@ -2669,6 +2669,11 @@ QUnit.test("Script evaluation", function (assert) {
         assert.equal(Intercooler._internal.getLocalURL("http://foo.bar", "doe, joe", "bar=foo&joe=blow"), "http://foo.bar?doe=&joe=blow");
         assert.equal(Intercooler._internal.getLocalURL("http://foo.bar", "doe,   joe", "bar=foo&joe=blow"), "http://foo.bar?doe=&joe=blow");
         assert.equal(Intercooler._internal.getLocalURL("http://foo.bar", " doe,   joe", "bar=foo&joe=blow"), "http://foo.bar?doe=&joe=blow");
+
+        // multiple params with same name 
+        assert.equal(Intercooler._internal.getLocalURL("http://foo.bar", "doe,joe", "bar=foo&joe=blow1&joe=blow2"), "http://foo.bar?doe=&joe=blow1&joe=blow2");
+        assert.equal(Intercooler._internal.getLocalURL("http://foo.bar", "doe,  bar,joe", "doe=&bar=foo1&bar=foo2&joe=blow1&joe=blow2"), "http://foo.bar?doe=&bar=foo1&bar=foo2&joe=blow1&joe=blow2");
+        assert.equal(Intercooler._internal.getLocalURL("http://foo.bar", "joe,bar", "joe=blow1&joe=blow2&bar="), "http://foo.bar?joe=blow1&joe=blow2&bar=");
       });
 
     </script>


### PR DESCRIPTION
…ent parameters with the same name (checkbox) could be pushed to url with ic-push-params, for example:

 &countries=russia&countries=ukraine. The previous version reduced this to the last given parameter (&countries=ukraine). Adds also 3 unit tests for getLocalUrl().